### PR TITLE
Support optional INIT_API_KEY for token WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 # log files
 Log/
 *.txt
+
+# vscode
+.vscode

--- a/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
+++ b/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
@@ -17,12 +17,14 @@ namespace Microsoft.SCIM.WebHostSample.Controllers
     [ApiController]
     public class TokenController : ControllerBase
     {
-        private readonly IConfiguration configuration;        
+        private readonly IConfiguration configuration;
+        private readonly string initAPIKey;
         private const int defaultTokenExpirationTimeInMins = 120;
 
         public TokenController(IConfiguration Configuration)
         {
             this.configuration = Configuration;
+            this.initAPIKey = this.configuration["INIT_API_KEY"];
         }
 
         private string GenerateJSONWebToken()
@@ -58,6 +60,14 @@ namespace Microsoft.SCIM.WebHostSample.Controllers
         [HttpGet]
         public ActionResult Get()
         {
+            if (!String.IsNullOrEmpty(this.initAPIKey))
+            {
+                if (Request.Headers["INIT_API_KEY"] != this.initAPIKey)
+                {
+                    return this.Unauthorized("This API Endpoint requires INIT_API_KEY to generate token");
+                }
+            }
+
             string tokenString = this.GenerateJSONWebToken();
             return this.Ok(new { token = tokenString });
         }


### PR DESCRIPTION
**_do not merge_**

Adds support for an optional INIT_API_KEY env variable that if set will require the same value be provided when requesting token.

- `GET /scim/token` will requre HEADER `INIT_API_KEY` with the value of the env variable `INIT_API_KEY` if it is set.

This is a special use case where a devt environment is publicly available (eg Azure hosted) but needs a level of restriction.
 

_WIP_: PR is just to highlight this commit for reuse, do not merge or PR upstream